### PR TITLE
Fix typo

### DIFF
--- a/.ideavimrc
+++ b/.ideavimrc
@@ -109,7 +109,7 @@ nmap gcO O<c-o>gcc
 " Lazy
 nmap <leader>l <Action>(WelcomeScreen.Plugins)
 " New File
-nmap <leader>fn Action(NewElementSamePlace)
+nmap <leader>fn <Action>(NewElementSamePlace)
 " Location List
 nmap <leader>xl <Action>(ActivateProblemsViewToolWindow)
 " Quickfix List


### PR DESCRIPTION
New file mapping was missing the open and closing carrots.