### PR TITLE
Emulate flash.nvim and mini.surround

### DIFF
--- a/.ideavimrc
+++ b/.ideavimrc
@@ -54,6 +54,7 @@ set easymotion
 set g:EasyMotion_do_mapping = 0
 nmap s <Plug>(easymotion-s)
 vmap s <Plug>(easymotion-s)
+omap s <Plug>(easymotion-s)
 
 " Enable the whichkey plugin, available on Jetbrains marketplace
 set which-key

--- a/.ideavimrc
+++ b/.ideavimrc
@@ -46,6 +46,7 @@ Plug 'tpope/vim-commentary'
 Plug 'tpope/vim-surround'
 set g:surround_no_mappings = 1
 nmap gsa <Plug>YSurround
+xmap gsa <Plug>VSurround
 nmap gsr <Plug>CSurround
 nmap gsd <Plug>DSurround
 
@@ -53,7 +54,7 @@ nmap gsd <Plug>DSurround
 set easymotion
 set g:EasyMotion_do_mapping = 0
 nmap s <Plug>(easymotion-s)
-vmap s <Plug>(easymotion-s)
+xmap s <Plug>(easymotion-s)
 omap s <Plug>(easymotion-s)
 
 " Enable the whichkey plugin, available on Jetbrains marketplace

--- a/.ideavimrc
+++ b/.ideavimrc
@@ -41,8 +41,20 @@ set shortmess=filnxtToOF
 
 " gcc and gc<action> mappings.
 Plug 'tpope/vim-commentary'
-" s action, such as cs"' (replace " with '), ds" (unquote)
+
+" Emulate LazyVim mini.surround mappings
 Plug 'tpope/vim-surround'
+set g:surround_no_mappings = 1
+nmap gsa <Plug>YSurround
+nmap gsr <Plug>CSurround
+nmap gsd <Plug>DSurround
+
+" Use s to jump anywhere (similar to flash.nvim in LazyVim)
+set easymotion
+set g:EasyMotion_do_mapping = 0
+nmap s <Plug>(easymotion-s)
+vmap s <Plug>(easymotion-s)
+
 " Enable the whichkey plugin, available on Jetbrains marketplace
 set which-key
 " Extended matching.  A Neovim default plugin.


### PR DESCRIPTION
Rather than using the default tpope/vim-surround mappings (which LazyVim doesn't use), instead use the default LazyVim mappings for mini.surround.

Also add in the default s behaviour emulating basics of flash.nvim