### PR TITLE
Add EasyMotion plugin installation as prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Required plugins from the [JetBrains Marketplace](https://plugins.jetbrains.com)
 
 - [IdeaVim](https://github.com/JetBrains/ideavim)
 - [Which-Key](https://github.com/TheBlob42/idea-which-key)
+- [EasyMotion](https://github.com/AlexPl292/IdeaVim-EasyMotion)
 
 ## Installation
 


### PR DESCRIPTION
If EasyMotion is not installed, when you press `s` some "easymotion" text is written.