### PR TITLE
feat: improve todo navigation

### DIFF
--- a/.ideavimrc
+++ b/.ideavimrc
@@ -421,17 +421,17 @@ nmap <leader>dw :echo 'There is no equivalent mapping for Widgets.'<cr>
 " Todo-comments Keymaps
 
 " Todo
-nmap <leader>st oTODO<esc>gcc
+nmap <leader>st <Action>(ActivateTODOToolWindow)
 " Todo/Fix/Fixme
-nmap <leader>sT :echo 'Not yet implemented.'<cr>
+nmap <leader>sT <Action>(ActivateTODOToolWindow)
 " Todo (Trouble)
-nmap <leader>xt :echo 'Not yet implemented.'<cr>
+nmap <leader>xt <Action>(ActivateTODOToolWindow)
 " Todo/Fix/Fixme (Trouble)
-nmap <leader>xT :echo 'Not yet implemented.'<cr>
+nmap <leader>xT <Action>(ActivateTODOToolWindow)
 " Previous Todo Comment
-nmap [t ?TODO<cr>
+nmap [t ?\(TODO\|FIX\|HACK\|WARN\|PERF\|NOTE\|TEST\):<cr>
 " Next Todo Comment
-nmap ]t /TODO<cr>
+nmap ]t /\(TODO\|FIX\|HACK\|WARN\|PERF\|NOTE\|TEST\):<cr>
 
 " DAP UI Keymaps
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Required plugins from the [JetBrains Marketplace](https://plugins.jetbrains.com)
 
 2. Restart your JetBrains IDE
 
+## Configuration Notes
+
+### TODO Navigation
+
+The TODO navigation keymaps (`<leader>st`, `<leader>xt`) use IDEA's built-in TODO tool window.
+
+**Note:** To support additional patterns beyond `TODO` (like `FIX` or `PERF`), configure them in `Settings → Editor → TODO → Patterns`.
+
 ## Development
 
 ### Notes and Caveats
@@ -34,10 +42,10 @@ Required plugins from the [JetBrains Marketplace](https://plugins.jetbrains.com)
 
 ### Roadmap
 
+- [x] Improve Todo comments functionality
 - [ ] Add Which-Key labels for all mappings
 - [ ] Test all mappings side-by-side with LazyVim
 - [ ] Compare Which-Key popups with LazyVim
-- [ ] Improve Todo comments functionality
 
 ### Future Considerations
 


### PR DESCRIPTION
Still room for improvement, but it covers the essential todo-comments workflow:
- Map TODO tool window to LazyVim keys (`st`, `sT`, `xt`, `xT`)
- Add navigation between comment tags with `[t` and `]t`
- Support standard markers (TODO, FIX, HACK, WARN, PERF, NOTE, TEST)
- Include setup instructions for custom patterns
