### PR TITLE
feat: add copy/paste to/from system clipboard

### DIFF
--- a/.ideavimrc
+++ b/.ideavimrc
@@ -24,6 +24,8 @@ set notimeout
 set undolevels=10000
 " Disable line wrap
 set nowrap
+" Enable copy/paste to/from system keyboard
+set clipboard+=unnamedplus
 
 " Neovim settings that differ from Vim
 " https://neovim.io/doc/user/diff.html


### PR DESCRIPTION
By default (unless in SSH mode), lazyvim enables copy/paste to/from the system clipboard ([Source](https://github.com/LazyVim/LazyVim/blob/ec5981dfb1222c3bf246d9bcaa713d5cfa486fbd/lua/lazyvim/config/options.lua#L57)).