### PR TITLE
Fix: EasyMotion,Surround default mappings not disabled as intended.

### DIFF
--- a/.ideavimrc
+++ b/.ideavimrc
@@ -46,7 +46,7 @@ Plug 'tpope/vim-commentary'
 
 " Emulate LazyVim mini.surround mappings
 Plug 'tpope/vim-surround'
-set g:surround_no_mappings = 1
+let g:surround_no_mappings = 1
 nmap gsa <Plug>YSurround
 xmap gsa <Plug>VSurround
 nmap gsr <Plug>CSurround
@@ -54,7 +54,7 @@ nmap gsd <Plug>DSurround
 
 " Use s to jump anywhere (similar to flash.nvim in LazyVim)
 set easymotion
-set g:EasyMotion_do_mapping = 0
+let g:EasyMotion_do_mapping = 0
 nmap s <Plug>(easymotion-s)
 xmap s <Plug>(easymotion-s)
 omap s <Plug>(easymotion-s)


### PR DESCRIPTION
Hi,

noticed that the the easymotion default mappings where not disabled.

E.g. `<leader><space>` should open files popup instead it triggers easymotion