### PR TITLE
Fix markdown installation codeblocks in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ Required plugins from the [JetBrains Marketplace](https://plugins.jetbrains.com)
 
 1. Download the `.ideavimrc` file from this repository to your home directory:
 
-   ```bash
-   # Unix/Linux/macOS
-   curl -Lo ~/.ideavimrc https://raw.githubusercontent.com/cufarvid/lazy-idea/refs/heads/main/.ideavimrc
+   **Unix/Linux/macOS**
 
-   # Windows
+   ```bash
+   curl -Lo ~/.ideavimrc https://raw.githubusercontent.com/cufarvid/lazy-idea/refs/heads/main/.ideavimrc
+   ```
+
+   **Windows**
+
+   ```powershell
    Invoke-WebRequest -OutFile "$HOME/.ideavimrc" -Uri https://raw.githubusercontent.com/cufarvid/lazy-idea/refs/heads/main/.ideavimrc
    ```
 


### PR DESCRIPTION
As described in the title, I wanted to separate the codeblocks for better ease of use with the copy button.