### PR TITLE
feat: add lazygit as optional plugin dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Required plugins from the [JetBrains Marketplace](https://plugins.jetbrains.com)
 - [Which-Key](https://github.com/TheBlob42/idea-which-key)
 - [EasyMotion](https://github.com/AlexPl292/IdeaVim-EasyMotion)
 
+Optional plugins from the [JetBrains Marketplace](https://plugins.jetbrains.com):
+
+- [LazyGit](https://github.com/ckob/lazygit-intellij-plugin)
+
 ## Installation
 
 Clone the repository to `~/.lazy-idea`:

--- a/modules/git.vim
+++ b/modules/git.vim
@@ -3,10 +3,18 @@
 " ========================================
 
 let g:WhichKeyDesc_git_ui = "<leader>gg GitUi (Root Dir)"
-nmap <leader>gg <Action>(ActivateCommitToolWindow)
+if exists('g:loaded_lazygit')
+    nmap <leader>gg <Action>(Lazygit.Toggle)
+else
+    nmap <leader>gg <Action>(ActivateCommitToolWindow)
+endif
 
 let g:WhichKeyDesc_git_ui_cwd = "<leader>gG GitUi (cwd)"
-nmap <leader>gG <Action>(ActivateCommitToolWindow)
+if exists('g:loaded_lazygit')
+    nmap <leader>gG <Action>(Lazygit.Toggle)
+else
+    nmap <leader>gG <Action>(ActivateCommitToolWindow)
+endif
 
 let g:WhichKeyDesc_git_blame = "<leader>gb Git Blame Line"
 nmap <leader>gb <Action>(Annotate)
@@ -31,3 +39,4 @@ nmap <leader>gs <Action>(Vcs.Show.Log)
 
 let g:WhichKeyDesc_git_explorer = "<leader>ge Git Explorer"
 nmap <leader>ge <Action>(ActivateVersionControlToolWindow)
+


### PR DESCRIPTION
Hi,

I've always been struggling to use LazyGit it in the IntelliJ IDEs. None of the existing integration methods was good enough IMO. So I went ahead and created [a plugin](https://github.com/ckob/lazygit-intellij-plugin) for it. I'm really happy with how it works so I wanted to share it here.

Following the #15 harpoon integration idea, I exposed a `g:loaded_lazygit = 1` variable when loading the plugin [in this commit](https://github.com/ckob/lazygit-intellij-plugin/commit/ea3668a6bcff437ae5f1b07bee9263d3c7dbda7d#diff-61f004274f63974ecb26c600b4ae3e91d7e1efe0a4787287f769dd3697c96928R10). So we could have an easy setup for the lazy-idea community.

I'm open to change the variable name, add another one, expose other lazygit invocation methods, etc. Open to any suggestions!