### PR TITLE
feat: use lazygit toggle current dir

### DIFF
--- a/modules/git.vim
+++ b/modules/git.vim
@@ -11,7 +11,7 @@ endif
 
 let g:WhichKeyDesc_git_ui_cwd = "<leader>gG GitUi (cwd)"
 if exists('g:loaded_lazygit')
-    nmap <leader>gG <Action>(Lazygit.Toggle)
+    nmap <leader>gG <Action>(Lazygit.ToggleCurrentDir)
 else
     nmap <leader>gG <Action>(ActivateCommitToolWindow)
 endif


### PR DESCRIPTION
As suggested in https://github.com/cufarvid/lazy-idea/pull/35#issuecomment-4247003821

Implemented in https://github.com/ckob/lazygit-intellij-plugin/pull/7 

Warning: It's available in the 0.3.0 version. There isn't a check of minimum version or something similar here. If anyone updates lazy-idea, but not the plugin, it would raise an error when using `<leader>gG>`. Personally I think it's acceptable since it's a corner case given the short time since we introduced it here. Thus I suppose plugins are updated more frequently than lazy-idea (because it's git-based).