### PR TITLE
feat: add inccommand=nosplit for live substitute preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Required plugins from the [JetBrains Marketplace](https://plugins.jetbrains.com):
 
-- [IdeaVim](https://github.com/JetBrains/ideavim)
+- [IdeaVim](https://github.com/JetBrains/ideavim) (>= 2.39.0, for `inccommand` support)
 - [Which-Key](https://github.com/TheBlob42/idea-which-key)
 - [EasyMotion](https://github.com/AlexPl292/IdeaVim-EasyMotion)
 

--- a/modules/settings.vim
+++ b/modules/settings.vim
@@ -20,6 +20,8 @@ set scrolloff=4
 set hlsearch
 " Show where search pattern typed so far matches
 set incsearch
+" Preview substitutions live as you type (requires IdeaVim >= 2.39.0)
+set inccommand=nosplit
 " Ignore case in search patterns
 set ignorecase
 " Override ignorecase if search pattern has uppercase


### PR DESCRIPTION
Mirrors LazyVim's live substitute preview (`inccommand=nosplit`).

IdeaVim added the option in [2.39.0](https://plugins.jetbrains.com/plugin/164-ideavim/versions/dev/1081389) ([VIM-2883](https://youtrack.jetbrains.com/issue/VIM-2883)). Matches LazyVim's [`options.lua`](https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/options.lua#L79).